### PR TITLE
Convert

### DIFF
--- a/src/com/amazon/ion/benchmark/ConvertOptionsCombination.java
+++ b/src/com/amazon/ion/benchmark/ConvertOptionsCombination.java
@@ -1,0 +1,24 @@
+package com.amazon.ion.benchmark;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Represents a combination of convert command options that corresponds to a single convert benchmark trial.
+ */
+class ConvertOptionsCombination extends OptionsCombinationBase {
+
+    /**
+     * @param serializedOptionsCombination text Ion representation of the options combination.
+     * @throws IOException if thrown while parsing the options combination.
+     */
+    ConvertOptionsCombination(String serializedOptionsCombination) throws IOException {
+        super(serializedOptionsCombination);
+    }
+
+    @Override
+    protected MeasurableTask createMeasurableTask(Path inputFile) throws Exception {
+        return null;
+    }
+
+}

--- a/src/com/amazon/ion/benchmark/ConvertOptionsMatrix.java
+++ b/src/com/amazon/ion/benchmark/ConvertOptionsMatrix.java
@@ -1,0 +1,26 @@
+package com.amazon.ion.benchmark;
+
+import com.amazon.ion.IonStruct;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents all convert command options combinations, corresponding to all convert benchmark trials. A single
+ * ConvertOptionsMatrix may yield multiple ConvertOptionsCombinations.
+ */
+public class ConvertOptionsMatrix extends OptionsMatrixBase {
+    /**
+     * @param optionsMatrix Map representing the options matrix for this command. The values of the map are either
+     *                      scalar values or Lists of scalar values.
+     */
+    ConvertOptionsMatrix(Map<String, Object> optionsMatrix)  {
+        super("convert", optionsMatrix);
+    }
+
+    @Override
+    void parseCommandSpecificOptions(Map<String, Object> optionsMatrix, List<IonStruct> optionsCombinationStructs) {
+        // no specific options for now
+    }
+
+}

--- a/src/com/amazon/ion/benchmark/ConvertOptionsMatrix.java
+++ b/src/com/amazon/ion/benchmark/ConvertOptionsMatrix.java
@@ -22,5 +22,4 @@ public class ConvertOptionsMatrix extends OptionsMatrixBase {
     void parseCommandSpecificOptions(Map<String, Object> optionsMatrix, List<IonStruct> optionsCombinationStructs) {
         // no specific options for now
     }
-
 }

--- a/src/com/amazon/ion/benchmark/Format.java
+++ b/src/com/amazon/ion/benchmark/Format.java
@@ -339,7 +339,7 @@ enum Format {
         // Identify output path
         Path outputPath =  Paths.get(inputFile.toFile().getName().substring(0, inputFileString.lastIndexOf('.')) + convert_format.getSuffix());
         if (results_file != null) {
-            String outputFile = optionsMap.get("--results-file").toString();
+            String outputFile = results_file.toString();
             outputPath =  Paths.get(outputFile);
         }
         // Create a convert combination option object for converting files

--- a/src/com/amazon/ion/benchmark/Format.java
+++ b/src/com/amazon/ion/benchmark/Format.java
@@ -322,6 +322,12 @@ enum Format {
         throw new IllegalArgumentException("Unknown file format.");
     }
 
+    /**
+     * Convert the file to the desired format by given options
+     * @param optionsMap Map representing the options.
+     * @return the Path of the converted file.
+     * @throws IOException if thrown while reading the data.
+     */
     static Path convertInputFormat(Map<String, Object> optionsMap) throws IOException {
         Object results_file = optionsMap.get("--results-file");
         // Identify input file
@@ -336,9 +342,9 @@ enum Format {
             String outputFile = optionsMap.get("--results-file").toString();
             outputPath =  Paths.get(outputFile);
         }
-        // Create a temporary READ option object for converting files
+        // Create a convert combination option object for converting files
         OptionsMatrixBase optionsMatrixBase = OptionsMatrixBase.from(optionsMap);
-        OptionsCombinationBase optionsCombinationBase = OptionsCombinationBase.from(optionsMatrixBase.serializedOptionsCombinations[0]);
+        ConvertOptionsCombination optionsCombinationBase = (ConvertOptionsCombination) OptionsCombinationBase.from(optionsMatrixBase.serializedOptionsCombinations[0]);
         // Convert the input file
         return convert_format.convert(
                 inputFile,

--- a/src/com/amazon/ion/benchmark/Format.java
+++ b/src/com/amazon/ion/benchmark/Format.java
@@ -81,6 +81,7 @@ enum Format {
         @Override
         Path convert(Path input, Path output, OptionsCombinationBase options) throws IOException {
             Format sourceFormat = classify(input);
+
             switch (sourceFormat) {
                 case ION_TEXT:
                     if (options.limit == Integer.MAX_VALUE) {

--- a/src/com/amazon/ion/benchmark/Format.java
+++ b/src/com/amazon/ion/benchmark/Format.java
@@ -343,8 +343,8 @@ enum Format {
             outputPath =  Paths.get(outputFile);
         }
         // Create a convert combination option object for converting files
-        OptionsMatrixBase optionsMatrixBase = OptionsMatrixBase.from(optionsMap);
-        ConvertOptionsCombination optionsCombinationBase = (ConvertOptionsCombination) OptionsCombinationBase.from(optionsMatrixBase.serializedOptionsCombinations[0]);
+        ConvertOptionsMatrix optionsMatrixBase = (ConvertOptionsMatrix) OptionsMatrixBase.from(optionsMap);
+        ConvertOptionsCombination optionsCombinationBase = (ConvertOptionsCombination) OptionsCombinationBase.from(optionsMatrixBase.getSerializedOptionsCombinations()[0]);
         // Convert the input file
         return convert_format.convert(
                 inputFile,

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -5,6 +5,7 @@ import org.docopt.Docopt;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +52,7 @@ public class Main {
 
         + "  ion-java-benchmark compare (--benchmark-result-previous <file_path>) (--benchmark-result-new <file_path>) <output_file>\n"
 
-        + "  ion-java-benchmark convert (--format <type>) (--output-file <file_path>) <input_file>\n"
+        + "  ion-java-benchmark convert (--format <type>) [--results-file <file>] <input_file>\n"
 
         + "  ion-java-benchmark --help\n"
 
@@ -352,23 +353,8 @@ public class Main {
             } else if (optionsMap.get("compare").equals(true)) {
                 ParseAndCompareBenchmarkResults.compareResult(optionsMap);
             } else if (optionsMap.get("convert").equals(true)) {
-                Path outputPath =  Paths.get(optionsMap.get("--output-file").toString() + "_2");
-                Path inputFile = Paths.get(optionsMap.get("<input_file>").toString());
-
-                String convert_format_str = ((List<String>) optionsMap.get("--format")).get(0);
-                Format convert_format = Format.valueOf(convert_format_str.toUpperCase());
-                System.out.println(convert_format);
-
-                OptionsMatrixBase options_1 = OptionsMatrixBase.from(optionsMap);
-                OptionsCombinationBase options_2 = OptionsCombinationBase.from(options_1.serializedOptionsCombinations[0]);
-
-                convert_format.convert(
-                    inputFile,
-                    outputPath,
-                    options_2
-                );
-            }
-            else {
+                Format.convertInputFormat(optionsMap);
+            } else {
                 OptionsMatrixBase options = OptionsMatrixBase.from(optionsMap);
                 options.executeBenchmark();
             }

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -2,6 +2,11 @@ package com.amazon.ion.benchmark;
 
 import org.docopt.Docopt;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class Main {
@@ -45,6 +50,8 @@ public class Main {
         + "  ion-java-benchmark run-suite (--test-ion-data <file_path>) (--benchmark-options-combinations <file_path>) <output_file>\n"
 
         + "  ion-java-benchmark compare (--benchmark-result-previous <file_path>) (--benchmark-result-new <file_path>) <output_file>\n"
+
+        + "  ion-java-benchmark convert (--format <type>) (--output-file <file_path>) <input_file>\n"
 
         + "  ion-java-benchmark --help\n"
 
@@ -242,7 +249,7 @@ public class Main {
 
         + "  -P --benchmark-result-previous <file_path>      This option will specify the path of benchmark result from the existing ion-java commit.\n"
 
-        + "  -X --benchmark-result-new <file_path>      This option will specify the path of benchmark result form the new ion-java commit.\n"
+        + "  -X --benchmark-result-new <file_path>      This option will specify the path of benchmark result from the new ion-java commit.\n"
 
         + "\n";
 
@@ -344,7 +351,24 @@ public class Main {
                 GenerateAndOrganizeBenchmarkResults.generateAndSaveBenchmarkResults(optionsMap);
             } else if (optionsMap.get("compare").equals(true)) {
                 ParseAndCompareBenchmarkResults.compareResult(optionsMap);
-            } else {
+            } else if (optionsMap.get("convert").equals(true)) {
+                Path outputPath =  Paths.get(optionsMap.get("--output-file").toString() + "_2");
+                Path inputFile = Paths.get(optionsMap.get("<input_file>").toString());
+
+                String convert_format_str = ((List<String>) optionsMap.get("--format")).get(0);
+                Format convert_format = Format.valueOf(convert_format_str.toUpperCase());
+                System.out.println(convert_format);
+
+                OptionsMatrixBase options_1 = OptionsMatrixBase.from(optionsMap);
+                OptionsCombinationBase options_2 = OptionsCombinationBase.from(options_1.serializedOptionsCombinations[0]);
+
+                convert_format.convert(
+                    inputFile,
+                    outputPath,
+                    options_2
+                );
+            }
+            else {
                 OptionsMatrixBase options = OptionsMatrixBase.from(optionsMap);
                 options.executeBenchmark();
             }

--- a/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
@@ -128,6 +128,8 @@ abstract class OptionsCombinationBase {
             options = new ReadOptionsCombination(optionsIon);
         } else if (firstAnnotation.equals("write")) {
             options = new WriteOptionsCombination(optionsIon);
+        } else if (firstAnnotation.equals("convert")) {
+            options = new ConvertOptionsCombination(optionsIon);
         } else {
             throw new IllegalArgumentException("Malformed options: must be annotated with the command name.");
         }

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -58,7 +58,7 @@ abstract class OptionsMatrixBase {
     };
 
     private final String inputFile;
-    private final String[] serializedOptionsCombinations;
+    public final String[] serializedOptionsCombinations;
     private final boolean profile;
     private final Options jmhOptions;
 
@@ -496,6 +496,8 @@ abstract class OptionsMatrixBase {
         if (optionsMatrix.get("write").equals(true)) {
             matrix = new WriteOptionsMatrix(optionsMatrix);
         } else if (optionsMatrix.get("read").equals(true)) {
+            matrix = new ReadOptionsMatrix(optionsMatrix);
+        } else if (optionsMatrix.get("convert").equals(true)) {
             matrix = new ReadOptionsMatrix(optionsMatrix);
         } else {
             throw new IllegalArgumentException("Unknown command. Select from: write, read.");

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -58,7 +58,8 @@ abstract class OptionsMatrixBase {
     };
 
     private final String inputFile;
-    public final String[] serializedOptionsCombinations;
+
+    private final String[] serializedOptionsCombinations;
     private final boolean profile;
     private final Options jmhOptions;
 

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -498,7 +498,7 @@ abstract class OptionsMatrixBase {
         } else if (optionsMatrix.get("read").equals(true)) {
             matrix = new ReadOptionsMatrix(optionsMatrix);
         } else if (optionsMatrix.get("convert").equals(true)) {
-            matrix = new ReadOptionsMatrix(optionsMatrix);
+            matrix = new ConvertOptionsMatrix(optionsMatrix);
         } else {
             throw new IllegalArgumentException("Unknown command. Select from: write, read.");
         }

--- a/src/com/amazon/ion/benchmark/TemporaryFiles.java
+++ b/src/com/amazon/ion/benchmark/TemporaryFiles.java
@@ -60,6 +60,7 @@ final class TemporaryFiles {
      * @throws IOException if thrown while trying to create the file.
      */
     static Path newTempFile(String prefix, String suffix) throws IOException {
+        System.out.println("???");
         return Files.createTempFile(tempDirectory, prefix, suffix);
     }
 }

--- a/src/com/amazon/ion/benchmark/TemporaryFiles.java
+++ b/src/com/amazon/ion/benchmark/TemporaryFiles.java
@@ -60,7 +60,6 @@ final class TemporaryFiles {
      * @throws IOException if thrown while trying to create the file.
      */
     static Path newTempFile(String prefix, String suffix) throws IOException {
-        System.out.println("???");
         return Files.createTempFile(tempDirectory, prefix, suffix);
     }
 }


### PR DESCRIPTION
extract the formats conversion function to a standalone command in benchmark-cli, aims to not break any existing command. 
#### Syntax:
```
ion-java-benchmark convert (--format <type>) [--results-file <file>] <input_file>
```
#### Example:
```
ion-java-benchmark convert --format json --results-file after_convert.json before_convert.ion
```